### PR TITLE
Bug 940183 - Upgrade npm dependencies and use new interfaces r=gaye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MARIONETTE_MOCHA?=./node_modules/.bin/marionette-mocha \
 default: node_modules lint test
 
 firefox:
-	./node_modules/.bin/mozilla-download --product firefox --verbose $@
+	./node_modules/.bin/mozilla-download --product firefox --branch nightly --channel prerelease  $@
 
 node_modules:
 	npm install

--- a/lib/host.js
+++ b/lib/host.js
@@ -29,10 +29,10 @@ Host.DEFAULT_FIREFOX_RUNTIME = path.join(process.cwd(), 'firefox');
 
 
 /**
- * Default version of firefox to use.
+ * Default branch of firefox to use.
  * @const {string}
  */
-Host.DEFAULT_FIREFOX_VERSION = 'nightly';
+Host.DEFAULT_FIREFOX_BRANCH = 'nightly';
 
 
 /**
@@ -75,10 +75,17 @@ Host.prototype = {
       this._options.runtime = Host.DEFAULT_FIREFOX_RUNTIME;
     }
 
-    mozDownload.download(
+    if (!this._options.branch) {
+      this._options.branch = Host.DEFAULT_FIREFOX_BRANCH;
+    }
+
+    mozDownload(
       'firefox',
-      this._options.runtime,
-      { version: this._options.version },
+      {
+        channel: 'prerelease',
+        branch: this._options.branch,
+        product: 'firefox'
+      },
       this._run.bind(this, profile, callback)
     );
   },
@@ -115,9 +122,10 @@ Host.prototype = {
       }, 2000);
     }).bind(this);
 
-    mozRunner.run('firefox', this._options.runtime, {
+    mozRunner.run('firefox', {
       argv: ['-marionette'],
-      profile: profile
+      profile: profile,
+      product: 'firefox'
     }, onChild);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marionette-firefox-host",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "Gareth Aye",
     "email": "gaye@mozilla.com"
@@ -8,16 +8,16 @@
 
   "devDependencies": {
     "empty-port": "0.0.1",
-    "marionette-client": "~0.12.0",
+    "marionette-client": "~1.1",
     "mocha": "1.12.0",
-    "mozilla-profile-builder": "~0.2.0",
-    "marionette-js-runner": "~0.0.1",
+    "mozilla-profile-builder": "~0.3",
+    "marionette-js-runner": "~0.3",
     "node-static": "0.6.9"
   },
 
   "dependencies": {
-    "mozilla-download": "0.2.1",
-    "mozilla-runner": "0.0.1",
+    "mozilla-download": "~0.4",
+    "mozilla-runner": "~0.2",
     "remove": "0.1.5"
   },
 


### PR DESCRIPTION
Upgrading libraries and updating interfaces to match the new libraries.

Note: I've also updated the version as I would hope we would publish a new version of this after. Thanks!
